### PR TITLE
fix bug on remaining lock file if sctime is stopped via windows logout

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -24,7 +24,6 @@ class DatasourceManager;
 class Lock;
 extern QDir configDir;
 extern QString lockfilePath;
-extern Lock *lock;
 void logError(const QString& msg);
 void trace(const QString& msg);
 QString canonicalPath(QString);

--- a/src/sctimeapp.cpp
+++ b/src/sctimeapp.cpp
@@ -1,0 +1,102 @@
+/*
+    Copyright (C) 2018 science+computing ag
+       Authors: Florian Schmitt et al.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License Version 3 as published by
+    the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "sctimeapp.h"
+#include "timemainwindow.h"
+#include "lock.h"
+#include "sctimexmlsettings.h"
+#include "setupdsm.h"
+
+#ifndef WIN32
+#include <signal.h>
+#include "unix/signalhandler.h"
+#endif
+
+// transform the value of a #define into a string in a portable way
+#define QUOTE_(x) #x
+#define QUOTE(x) QUOTE_(x)
+
+
+SctimeApp::SctimeApp(int &argc, char **argv):QApplication(argc, argv) {
+    mainWindow=NULL;
+    m_lock=NULL;
+#ifndef WIN32
+    term = NULL;
+    hup = NULL;
+    int_ = NULL;
+    cont = NULL;
+#endif
+    // necessary for XSM support
+    setObjectName("sctime");
+    setApplicationName("sctime");
+    setApplicationVersion(QUOTE(APP_VERSION));
+}
+
+#ifdef WIN32
+// catch suspend and resume events and handle them by calling "suspend()" or "resume()"
+bool SctimeApp::winEventFilter(MSG * msg, long * result) {
+  if (msg->message == WM_POWERBROADCAST && mainWindow && msg->hwnd == (HWND)mainWindow->winId()) {
+    if (msg->wParam == PBT_APMRESUMEAUTOMATIC)
+      QMetaObject::invokeMethod(mainWindow, "resume", Qt::QueuedConnection);
+    else if (msg->wParam == PBT_APMSUSPEND)
+      QMetaObject::invokeMethod(mainWindow, "suspend", Qt::QueuedConnection);
+    else return false;
+    *result = TRUE;
+    return true;
+  }
+  return false;
+}
+#endif
+
+void SctimeApp::init(Lock* lock, QStringList& dataSourceNames, const QString& zeitkontenfile,
+ const QString& bereitschaftsfile, const QString& specialremunfile, const QString& offlinefile)
+{
+  m_lock=lock;
+  SCTimeXMLSettings settings;
+  settings.readSettings();
+  if (dataSourceNames.isEmpty()) dataSourceNames = settings.backends.split(" ");
+  setupDatasources(dataSourceNames, settings, zeitkontenfile, bereitschaftsfile, specialremunfile,offlinefile);
+  mainWindow = new TimeMainWindow(m_lock);
+#ifndef WIN32
+  term = new SignalHandler(SIGTERM);
+  connect(term, SIGNAL(received()), this, SLOT(closeAllWindows()));
+  hup = new SignalHandler(SIGHUP);
+  connect(hup, SIGNAL(received()), this, SLOT(closeAllWindows()));
+  int_ = new SignalHandler(SIGINT);
+  connect(int_, SIGNAL(received()), this, SLOT(closeAllWindows()));
+  cont = new SignalHandler(SIGCONT);
+  connect(cont, SIGNAL(received()), mainWindow, SLOT(resume()));
+#endif
+  connect(this, SIGNAL(aboutToQuit()), this, SLOT(cleanup()));
+  mainWindow->show();
+}
+
+void SctimeApp::cleanup() {
+  m_lock->release();
+}
+
+SctimeApp::~SctimeApp() {
+  delete mainWindow;
+  delete kontenDSM;
+  delete bereitDSM;
+#ifndef WIN32
+  delete term;
+  delete hup;
+  delete int_;
+  delete cont;
+#endif
+}

--- a/src/sctimeapp.h
+++ b/src/sctimeapp.h
@@ -1,0 +1,57 @@
+/*
+    Copyright (C) 2018 science+computing ag
+       Authors: Florian Schmitt et al.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License Version 3 as published by
+    the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef SCTIMEAPP_H
+#define SCTIMEAPP_H
+
+#include <QApplication>
+
+#ifdef WIN32
+#include <windows.h>
+#endif
+
+class Lock;
+class TimeMainWindow;
+class SignalHandler;
+
+class SctimeApp : public QApplication {
+Q_OBJECT
+
+public:
+    SctimeApp(int &argc, char **argv);
+    virtual ~SctimeApp();
+#ifdef WIN32
+    // catch suspend and resume events and handle them by calling "suspend()" or "resume()"
+    virtual bool winEventFilter(MSG * msg, long * result);
+#endif
+
+   void init(Lock* lock, QStringList& dataSourceNames, const QString& zeitkontenfile,
+             const QString& bereitschaftsfile, const QString& specialremunfile, const QString& offlinefile);
+public slots:
+   void cleanup(); 
+private:
+   Lock *m_lock;
+   TimeMainWindow* mainWindow;
+#ifndef WIN32
+   SignalHandler* term;
+   SignalHandler* hup;
+   SignalHandler* int_;
+   SignalHandler* cont;
+#endif
+};
+
+#endif

--- a/src/src.pro
+++ b/src/src.pro
@@ -10,8 +10,18 @@ QT += xml gui core network sql widgets
 TARGET = sctime
 CODECFORTR= UTF-8
 TRANSLATIONS = sctime_de.ts
-SOURCES = abteilungsliste.cpp bereitschaftsliste.cpp bereitschaftsmodel.cpp bereitschaftsview.cpp datasource.cpp datedialog.cpp defaultcomment.cpp defaultcommentreader.cpp defaulttagreader.cpp descdata.cpp findkontodialog.cpp kontotreeitem.cpp kontotreeview.cpp lock.cpp preferencedialog.cpp sctime.cpp sctimexmlsettings.cpp setupdsm.cpp timemainwindow.cpp unterkontodialog.cpp specialremunerationsdialog.cpp specialremuntypemap.cpp statusbar.cpp JSONReader.cpp textviewerdialog.cpp
-HEADERS = abteilungsliste.h bereitschaftsliste.h bereitschaftsmodel.h bereitschaftsview.h datasource.h datedialog.h defaultcomment.h defaultcommentreader.h defaulttagreader.h descdata.h eintragsliste.h findkontodialog.h globals.h kontodateninfo.h kontoliste.h kontotreeitem.h kontotreeview.h lock.h preferencedialog.h sctimexmlsettings.h setupdsm.h statusbar.h timecounter.h timeedit.h timemainwindow.h unterkontodialog.h unterkontoeintrag.h unterkontoliste.h specialremunerationsdialog.h specialremuntypemap.h JSONReader.h util.h textviewerdialog.h
+SOURCES = abteilungsliste.cpp bereitschaftsliste.cpp bereitschaftsmodel.cpp bereitschaftsview.cpp\
+          datasource.cpp datedialog.cpp defaultcomment.cpp defaultcommentreader.cpp defaulttagreader.cpp\
+          descdata.cpp findkontodialog.cpp kontotreeitem.cpp kontotreeview.cpp lock.cpp preferencedialog.cpp\
+          sctime.cpp sctimexmlsettings.cpp setupdsm.cpp timemainwindow.cpp unterkontodialog.cpp\
+          specialremunerationsdialog.cpp specialremuntypemap.cpp statusbar.cpp JSONReader.cpp\
+          textviewerdialog.cpp sctimeapp.cpp
+HEADERS = abteilungsliste.h bereitschaftsliste.h bereitschaftsmodel.h bereitschaftsview.h datasource.h\
+          datedialog.h defaultcomment.h defaultcommentreader.h defaulttagreader.h descdata.h eintragsliste.h\
+          findkontodialog.h globals.h kontodateninfo.h kontoliste.h kontotreeitem.h kontotreeview.h lock.h\
+          preferencedialog.h sctimexmlsettings.h setupdsm.h statusbar.h timecounter.h timeedit.h timemainwindow.h\
+          unterkontodialog.h unterkontoeintrag.h unterkontoliste.h specialremunerationsdialog.h\
+          specialremuntypemap.h JSONReader.h util.h textviewerdialog.h sctimeapp.h
 RESOURCES = ../pics/sctimeImages.qrc ../help/help.qrc
 GENERATED_RESOURCES = translations.qrc
 FORMS = datedialogbase.ui preferencedialogbase.ui specialremunerationdialogbase.ui

--- a/src/timemainwindow.cpp
+++ b/src/timemainwindow.cpp
@@ -76,7 +76,8 @@ void logError(const QString &msg) {
 }
 
 /** Erzeugt ein neues TimeMainWindow, das seine Daten aus abtlist bezieht. */
-TimeMainWindow::TimeMainWindow():QMainWindow(), startTime(QDateTime::currentDateTime()) {
+TimeMainWindow::TimeMainWindow(Lock* lock):QMainWindow(), startTime(QDateTime::currentDateTime()) {
+  m_lock = lock;
   paused = false;
   sekunden = 0;
   setObjectName(tr("sctime"));
@@ -839,11 +840,11 @@ void TimeMainWindow::save()
 }
 
 void TimeMainWindow::checkLock() {
-  if (!lock->check()) {
+  if (!m_lock->check()) {
     QMessageBox msg;
     msg.setText(tr("The program will quit in a few seconds without saving."));
-    msg.setInformativeText(lock->errorString());
-    qDebug() << tr("The program will now quit without saving.") << lock->errorString();
+    msg.setInformativeText(m_lock->errorString());
+    qDebug() << tr("The program will now quit without saving.") << m_lock->errorString();
     QTimer::singleShot(10000, this, SLOT(quit()));
     msg.exec();
   }

--- a/src/timemainwindow.h
+++ b/src/timemainwindow.h
@@ -40,6 +40,7 @@ class QTextBrowser;
 #include "datasource.h"
 
 class TextViewerDialog;
+class Lock;
 
 /** Diese Klasse implementiert das Hauptfenster des Programms,
     und sorgt zudem fuer das Fortschreiten der Zeit.
@@ -48,7 +49,7 @@ class TimeMainWindow: public QMainWindow
 {
     Q_OBJECT
 public:
-    TimeMainWindow();
+    TimeMainWindow(Lock* lock);
     QTreeWidget* getKontoTree();
     virtual ~TimeMainWindow();
     SCTimeXMLSettings* settings;
@@ -172,6 +173,7 @@ public:
   protected:
     virtual void moveEvent( QMoveEvent *event);
   private:
+    TimeMainWindow() {};
     void checkLock();
     void updateTaskbarTitle(int zeit);
     void closeEvent(QCloseEvent * event);
@@ -182,6 +184,7 @@ public:
     void cantMoveTimeDialog(int delta);
     KontoTreeView* kontoTree;
     UnterKontoDialog* unterKontoDialog;
+    Lock *m_lock;
     QAction* editUnterKontoAction;
     QAction* inPersKontAction;
     QAction* abzurMin5PlusAction;


### PR DESCRIPTION
QT doesn't guarantee that after the exec function of the main app any other code is executed. This happens e.g on windows on log out (see http://doc.qt.io/qt-5/qcoreapplication.html#exec ). So we need to restructure initialization and cleanup a bit.