### PR TITLE
Downgrade dmg filesystem to HFS+ for old systems

### DIFF
--- a/extra/mac/sctime-mac-dist
+++ b/extra/mac/sctime-mac-dist
@@ -117,7 +117,7 @@ rm -rf "$dmgdir" && \
 	rm -f "$dmgname".dmg && \
 	mkdir -p "$dmgdir" && \
 	rsync -aSH --delete "$approot" "$dmgdir" && \
-	hdiutil create "$dmgname".dmg -volname "$dmgname" -srcfolder dmg && \
+	hdiutil create "$dmgname".dmg -volname "$dmgname" -srcfolder dmg -fs "HFS+" && \
 	rm -rf dmg || \
 	exit 1
 


### PR DESCRIPTION
Minor tweak for the Mac to create the dmg image with a backward-compatible filesystem.