### PR TITLE
Draft: change behaviour of datePicker depending on singleclickmode

### DIFF
--- a/src/datedialog.h
+++ b/src/datedialog.h
@@ -24,7 +24,6 @@
 #include <QDateTime>
 #include <QDialog>
 
-
  /**
   * Dialog to read a date
   */
@@ -33,8 +32,8 @@ class DateDialog : public QDialog, private Ui::DateDialogBase
   Q_OBJECT
 
 public:
-  DateDialog(const QDate& datum, QWidget* parent = 0);
-  ~DateDialog();
+  DateDialog(const QDate& datum, QWidget* parent = 0, bool singleclickactivation=false);
+  virtual ~DateDialog();
   /*$PUBLIC_FUNCTIONS$*/
 
 public slots:
@@ -57,6 +56,7 @@ signals:
 
 private:
   QDate selectedDate;
+  static QStyle* datePickerStyle;
 };
 
 #endif

--- a/src/timemainwindow.cpp
+++ b/src/timemainwindow.cpp
@@ -1414,7 +1414,7 @@ void TimeMainWindow::callDateDialog()
     QApplication::setFont(QFont(custFont,custFontSize));
   }
 
-  DateDialog * dateDialog=new DateDialog(abtList->getDatum(), this);
+  DateDialog * dateDialog=new DateDialog(abtList->getDatum(), this, settings->singleClickActivation());
   connect(dateDialog, SIGNAL(dateChanged(const QDate&)), this, SLOT(changeDate(const QDate&)));
   dateDialog->setAttribute(Qt::WA_DeleteOnClose);
   dateDialog->show();


### PR DESCRIPTION
for some reason this does not work. Not sure why - the code of QCalendarWidget seems to check for QStyle::SH_ItemView_ActivateItemOnSingleClick, but in practice the calls don't seem to arrive.
There must be a way to handle single clicks differently, as setting the environment variable KDE_SESSION_VERSION=4 seems to change the behaviour. I could debug it properly, but I don't care too much, as I'm not sure if we really want this feature. I just put is as a pull request here and let it rot :-)