### PR TITLE
Make find dialog more compact

### DIFF
--- a/src/findkontodialog.cpp
+++ b/src/findkontodialog.cpp
@@ -23,7 +23,6 @@
 #include <QTreeWidget>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
-#include <QGridLayout>
 
 #include "abteilungsliste.h"
 #include "kontotreeview.h"
@@ -60,15 +59,8 @@ FindKontoDialog::FindKontoDialog(AbteilungsListe* abtlist, QWidget * parent):QDi
 
 void FindKontoDialog::createLayout()
 {
-  mainLayout = new QGridLayout(this);
-
-  leftLayout=new QVBoxLayout();
-  rightLayout=new QVBoxLayout();
+  mainLayout = new QVBoxLayout(this);
   buttonLayout=new QHBoxLayout();
-
-  mainLayout->addLayout(leftLayout, 0, 0, Qt::AlignLeft | Qt::AlignTop);
-  mainLayout->addLayout(rightLayout, 0, 1, Qt::AlignLeft | Qt::AlignTop);
-  mainLayout->addLayout(buttonLayout, 1, 1, Qt::AlignRight | Qt::AlignBottom);
 }
 
 void FindKontoDialog::createWidgets()
@@ -83,17 +75,13 @@ void FindKontoDialog::createWidgets()
   valueChoose->setEditable(true);
   valueChoose->setAutoCompletion(false);
   valueChoose->setFocus();
+  valueChoose->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+  valueChoose->setMinimumContentsLength(40);
 
-  leftLayout->addWidget(new QLabel(tr("Please select type of item to search for:"),this));
-  leftLayout->addWidget(typeChoose);
-  leftLayout->addWidget(new QLabel(tr("Please select name of item to search for:"), this));
-  leftLayout->addWidget(valueChoose);
-
-  resultTree = new QTreeWidget(this);
-  resultTree->setHeaderLabel(tr("Search result"));
-  resultTree->setColumnCount(1) ;
-  resultTree->setSelectionMode(QAbstractItemView::SingleSelection);
-  rightLayout->addWidget(resultTree);
+  mainLayout->addWidget(new QLabel(tr("Please select type of item to search for:"),this));
+  mainLayout->addWidget(typeChoose);
+  mainLayout->addWidget(new QLabel(tr("Please select name of item to search for:"), this));
+  mainLayout->addWidget(valueChoose);
 
   okButton=new QPushButton( tr("&OK"), this );
   okButton->setEnabled(false);
@@ -105,6 +93,13 @@ void FindKontoDialog::createWidgets()
   buttonLayout->addWidget(searchButton);
   buttonLayout->addWidget(okButton);
   buttonLayout->addWidget(cancelButton);
+  mainLayout->addLayout(buttonLayout, Qt::AlignRight | Qt::AlignBottom);
+
+  resultTree = new QTreeWidget(this);
+  resultTree->setHeaderLabel(tr("Search result"));
+  resultTree->setColumnCount(1) ;
+  resultTree->setSelectionMode(QAbstractItemView::SingleSelection);
+  mainLayout->addWidget(resultTree);
 }
 
 void FindKontoDialog::createConnects()

--- a/src/findkontodialog.h
+++ b/src/findkontodialog.h
@@ -25,7 +25,6 @@ class QComboBox;
 class QTreeWidget;
 class QVBoxLayout;
 class QTreeWidgetItem;
-class QGridLayout;
 class QHBoxLayout;
 
 class AbteilungsListe;
@@ -60,9 +59,7 @@ class FindKontoDialog: public QDialog
     void setFoundItem(QTreeWidgetItem* item);
     QStringList getNamesFromTreeItems();
 
-    QGridLayout *mainLayout;
-    QVBoxLayout *leftLayout;
-    QVBoxLayout *rightLayout;
+    QVBoxLayout *mainLayout;
     QHBoxLayout *buttonLayout;
 
     QComboBox *kontoChoose;


### PR DESCRIPTION
If there were very long comments, the value chooser combo box would
extend to accomodate them. This would not only extend the window beyond
screen size but also push the result tree view and buttons off screen.

Make the dialog more compact by moving the result tree view below the
search selectors and buttons and also making the value chooser combo box
start off with a width of only 40 characters.