### PR TITLE
Fix reading of nonexistant offline JSON

### DIFF
--- a/src/JSONReader.cpp
+++ b/src/JSONReader.cpp
@@ -143,7 +143,7 @@ int JSONReaderBase::loadDataNewerThan(int version)
   QByteArray byteData;
   try {
      byteData = getByteArray();
-  } catch (JSONReaderException &e) {
+  } catch (JSONReaderException *e) {
     return INVALIDDATA;
   }
   data=QJsonDocument::fromJson(byteData);


### PR DESCRIPTION
When sctime-offline.json does not exist, sctime would die with an error
at startup:

terminate called after throwing an instance of 'JSONReaderException*'
Aborted (core dumped)

gdb reveals that it's related to loadDataNewerThan() and getByteArray()
(which makes sense because they're the only places, exceptions are
used):

(gdb) bt
 #0  0x00007ffff669ab01 in raise () from /lib64/libc.so.6
 #1  0x00007ffff6684537 in abort () from /lib64/libc.so.6
 #2  0x00007ffff6a0c8ce in ?? () from /usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/libstdc++.so.6
 #3  0x00007ffff6a3b7d6 in ?? () from /usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/libstdc++.so.6
 #4  0x00007ffff6a3b841 in std::terminate() () from /usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/libstdc++.so.6
 #5  0x00007ffff6a3bad3 in __cxa_throw () from /usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/libstdc++.so.6
 #6  0x0000555555576cbe in JSONReaderFile::getByteArray() [clone .cold] ()
 #7  0x00005555555b4afc in JSONReaderBase::loadDataNewerThan(int) ()
 #8  0x00005555555b4a6a in JSONSource::read(QList<QStringList>*) ()
 #9  0x000055555558121f in DatasourceManager::start() ()
 #10 0x00007ffff6eef5aa in QObject::event(QEvent*) () from /usr/lib64/libQt5Core.so.5
 #11 0x00007ffff7a7703f in QApplicationPrivate::notify_helper(QObject*, QEvent*) () from /usr/lib64/libQt5Widgets.so.5
 #12 0x00007ffff6ec89c0 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () from /usr/lib64/libQt5Core.so.5
 #13 0x00007ffff6ecb5ea in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) () from /usr/lib64/libQt5Core.so.5
 #14 0x00007ffff6f12f13 in ?? () from /usr/lib64/libQt5Core.so.5
 #15 0x00007ffff5ab543b in g_main_context_dispatch () from /usr/lib64/libglib-2.0.so.0
 #16 0x00007ffff5ab56e8 in ?? () from /usr/lib64/libglib-2.0.so.0
 #17 0x00007ffff5ab579f in g_main_context_iteration () from /usr/lib64/libglib-2.0.so.0
 #18 0x00007ffff6f129cb in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () from /usr/lib64/libQt5Core.so.5
 #19 0x00007ffff6ec743b in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () from /usr/lib64/libQt5Core.so.5
 #20 0x00007ffff6ecedf2 in QCoreApplication::exec() () from /usr/lib64/libQt5Core.so.5
 #21 0x0000555555577c2f in main ()

The error is fixed by changing the variable in the catch statement in
loadDataNewerThan() from reference to pointer since that is what new returns in
getByteArray().

Alternatively, the exception could be a static (global?) object to which
a reference can be taken.

Signed-off-by: Michael Weiser <michael.weiser@gmx.de>